### PR TITLE
never execute tasks using thread pool

### DIFF
--- a/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
@@ -182,11 +182,8 @@ public class AudioRecorder {
     @SuppressLint("NewApi")
     public void start(final OnStartListener listener) {
         StartRecordTask task = new StartRecordTask();
-        if (ApiHelper.HAS_EXECUTE_ON_EXECUTOR_METHOD) {
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, listener);
-        } else {
-            task.execute(listener);
-        }
+        task.execute(listener);
+
     }
 
     /**
@@ -195,11 +192,8 @@ public class AudioRecorder {
     @SuppressLint("NewApi")
     public void pause(final OnPauseListener listener) {
         PauseRecordTask task = new PauseRecordTask();
-        if (ApiHelper.HAS_EXECUTE_ON_EXECUTOR_METHOD) {
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, listener);
-        } else {
-            task.execute(listener);
-        }
+        task.execute(listener);
+
     }
 
     public Status getStatus() {


### PR DESCRIPTION
Executing pause and play tasks using the thread pool executor can cause IllegalStateExceptions if one of the background thread methods takes a long time.  They really should be executed serially with async task to avoid this concurrency issue.