### PR TITLE
Fixing squid: S3398 "private" methods called only by inner classes should be moved to those classes

### DIFF
--- a/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
@@ -116,7 +116,9 @@ public class AudioRecorder {
 
     class PauseRecordTask extends AsyncTask<OnPauseListener, Void, Exception> {
         private OnPauseListener mOnPauseListener;
-
+        private void appendToFile(@NonNull final String targetFileName, @NonNull final String newFileName) {
+            Mp4ParserWrapper.append(targetFileName, newFileName);
+        }
         @Override
         protected Exception doInBackground(OnPauseListener... params) {
             mOnPauseListener = params[0];
@@ -258,9 +260,7 @@ public class AudioRecorder {
         return mContext.getCacheDir().getAbsolutePath() + File.separator + "tmprecord";
     }
 
-    private void appendToFile(@NonNull final String targetFileName, @NonNull final String newFileName) {
-        Mp4ParserWrapper.append(targetFileName, newFileName);
-    }
+
 
     /**
      * Drops the current recording.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S3398 - “"private" methods called only by inner classes should be moved to those classes”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S3398
 Please let me know if you have any questions.
Fevzi Ozgul