### PR TITLE
Fixing squid:MissingDeprecatedCheck:  Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/AudioRecorder.java
@@ -172,6 +172,7 @@ public class AudioRecorder {
      *
      * @deprecated Use AudioRecorderBuilder instead.
      */
+    @Deprecated
     public static AudioRecorder build(@NonNull final Context context,
                                       @NonNull final String targetFileName) {
         return build(context, targetFileName, MediaRecorderConfig.DEFAULT);
@@ -182,6 +183,7 @@ public class AudioRecorder {
      *
      * @deprecated Use AudioRecorderBuilder instead.
      */
+    @Deprecated
     public static AudioRecorder build(@NonNull final Context context,
                                       @NonNull final String targetFileName,
                                       @NonNull final MediaRecorderConfig mediaRecorderConfig) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:MissingDeprecatedCheck - “Deprecated elements should have both the annotation and the Javadoc tag”. You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
 Please let me know if you have any questions.
 Fevzi Ozgul