### PR TITLE
Fixing: squid: S1213  The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/sample/src/main/java/com/github/lassana/continuous_audiorecorder/RecorderApplication.java
+++ b/sample/src/main/java/com/github/lassana/continuous_audiorecorder/RecorderApplication.java
@@ -11,7 +11,7 @@ import com.github.lassana.recorder.AudioRecorder;
  * @since 11/26/14.
  */
 public class RecorderApplication extends Application {
-
+    private AudioRecorder mAudioRecorder;
     public static RecorderApplication getApplication(@NonNull Context context) {
         if (context instanceof RecorderApplication) {
             return (RecorderApplication) context;
@@ -19,7 +19,7 @@ public class RecorderApplication extends Application {
         return (RecorderApplication) context.getApplicationContext();
     }
 
-    private AudioRecorder mAudioRecorder;
+
 
     public void setRecorder(@NonNull AudioRecorder recorder) {
         mAudioRecorder = recorder;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
Fevzi Ozgul