### PR TITLE
Fixing: squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/recorder/src/main/java/com/github/lassana/recorder/ApiHelper.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/ApiHelper.java
@@ -9,7 +9,7 @@ import android.os.Build;
  * @since 8/25/13
  */
 public class ApiHelper {
-
+    private ApiHelper(){}
     public static final boolean HAS_EXECUTE_ON_EXECUTOR_METHOD =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 

--- a/recorder/src/main/java/com/github/lassana/recorder/Mp4ParserWrapper.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/Mp4ParserWrapper.java
@@ -23,7 +23,7 @@ import java.util.List;
  * @since 8/25/13
  */
 public class Mp4ParserWrapper {
-
+    private Mp4ParserWrapper(){}
     public static final String TAG = "Mp4ParserWrapper";
 
     public static final int FILE_BUFFER_SIZE = 1024;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
 Fevzi Ozgul