### PR TITLE
Update Mp4ParserWrapper.java

### DIFF
--- a/recorder/src/main/java/com/github/lassana/recorder/Mp4ParserWrapper.java
+++ b/recorder/src/main/java/com/github/lassana/recorder/Mp4ParserWrapper.java
@@ -45,9 +45,9 @@ public final class Mp4ParserWrapper {
                 copyFile(tmpFileName, mainFileName);
                 rvalue = anotherFile.delete() && new File(tmpFileName).delete();
             } else {
-                if (targetFile.getParentFile().mkdirs()
-                        && targetFile.createNewFile()
-                        && targetFile.exists()) {
+                if ((targetFile.getParentFile().mkdirs()
+                        && targetFile.createNewFile())
+                        || targetFile.exists()) {
                     copyFile(anotherFileName, mainFileName);
                     rvalue = anotherFile.delete();
                 } else {


### PR DESCRIPTION
`getApplicationContext().getExternalFilesDir(null).mkdirs()` returns false. Therefore if the parent of `targetFile` is `getApplicationContext().getExternalFilesDir(null)` then the recorder will fail for no reason.
Also if `targetFile.exists() && targetFile.length() == 0` it will fail for no reason, because `targetFile.createNewFile` will return false.
Therefore I'm proposing this change so that if targetFile exists there is no reason not to go ahead and copy to `targetFile`
Thank you